### PR TITLE
empty/rebuild in order of deck name

### DIFF
--- a/RebuildAll.py
+++ b/RebuildAll.py
@@ -16,7 +16,7 @@ from aqt.utils import tooltip
 
 
 def _updateFilteredDecks(actionFuncName):
-    dynDeckIds = [ d["id"] for d in mw.col.decks.all() if d["dyn"] ]
+    dynDeckIds = [ d["id"] for d in sorted(mw.col.decks.all(),key=lambda d:d["name"]) if d["dyn"] ]
     count = len(dynDeckIds)
 
     if not count:
@@ -28,7 +28,7 @@ def _updateFilteredDecks(actionFuncName):
 
     mw.checkpoint("{0} {1} filtered decks".format(actionFuncName, count))
     mw.progress.start()
-    [ actionFunc(did) for did in sorted(dynDeckIds) ]
+    [ actionFunc(did) for did in dynDeckIds ]
     mw.progress.finish()
     tooltip("Updated {0} filtered decks.".format(count))
 


### PR DESCRIPTION
This pull request changes the previous behavior of the add-on from emptying & rebuilding in order of Deck ID to doing so in order of Deck Name. This change is proposed so that users can control the order in which decks are emptied/rebuilt by changing the deck name (i.e. prefixing all filtered decks names with a number) rather than by the order in which filtered decks are created.

An example would be

Notes with tags:
```
note1 [tag1]
note2 [tag2]
note3 [tag1,tag2]
```

Filtered deck fd1:
````tag:tag1```` 

Filtered deck fd2:
```tag:tag2```

And I want to be able to control whether note3 goes into fd1 or fd2.

This change could potentially break behavior for anyone who relied on the previous behavior to accomplish the same type of control (by creating filtered decks in a specific order), but I would contend that anyone willing to put in that kind of work to achieve the same effect would welcome an easier method. This change is unlikely to affect users who do not rely on any specific sort behavior otherwise.